### PR TITLE
Add GPS LoRa TX/RX examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,8 @@
 
 
     
+
+## Example GPS LoRa sketches
+
+Two example sketches demonstrate sending GPS data over an E220 LoRa radio. `GPSv3_esp32_LoRa_TX` reads the NEO GPS on an ESP32 and sends latitude, longitude, altitude and satellite count as a binary structure. `GPSv3_esp32_LoRa_RX` receives the structure and prints the values to the serial monitor.
+

--- a/sketches/E220_GOOD_PRACTICE/E220.cpp
+++ b/sketches/E220_GOOD_PRACTICE/E220.cpp
@@ -1,15 +1,15 @@
 #include "E220.h"
 
-LoRa_E220 e220ttl(RX_PIN, TX_PIN, &Serial2, AUX_PIN, M0_PIN, M1_PIN, UART_BPS_RATE_9600);
+LoRa_E220 e220(RX_PIN, TX_PIN, &Serial2, AUX_PIN, M0_PIN, M1_PIN, UART_BPS_RATE_9600);
 
 void initE220() {
-  e220ttl.begin();
+  e220.begin();
   Serial.println("E220 module initialized");
 }
 
 void configE220() {
   ResponseStructContainer c;
-  c = e220ttl.getConfiguration();
+  c = e220.getConfiguration();
   Configuration configuration = *(Configuration*) c.data;
 
   configuration.ADDL = BROADCAST_ADDRESS;
@@ -26,26 +26,46 @@ void configE220() {
   configuration.TRANSMISSION_MODE.enableLBT = LBT_DISABLED;
   configuration.TRANSMISSION_MODE.WORPeriod = WOR_2000_011;
 
-  e220ttl.setConfiguration(configuration, WRITE_CFG_PWR_DWN_SAVE);
+  e220.setConfiguration(configuration, WRITE_CFG_PWR_DWN_SAVE);
   c.close();
 
   Serial.println("E220 module configured");
 }
 
 void sendE220Message(int channel, const String& message) {
-  ResponseStatus rs = e220ttl.sendBroadcastFixedMessage(comChan, message);
+  ResponseStatus rs = e220.sendBroadcastFixedMessage(comChan, message);
   //Serial.println(rs.getResponseDescription());
 }
 
 
+// not sure if i did it right
+void gpsDataRX(){
+    if (e220.available() > 1) {
+        ResponseStructContainer rsc = e220.receiveMessage(sizeof(GpsData));
+        if (rsc.status.code == 1) {
+            GpsData data = *(GpsData*)rsc.data;
+            Serial.print(F("Lat: ")); Serial.print(data.lat, 6);
+            Serial.print(F(" Lon: ")); Serial.print(data.lon, 6);
+            Serial.print(F(" Alt: ")); Serial.print(data.alt);
+            Serial.print(F(" Sat: ")); Serial.println(data.sat);
+        } else {
+            Serial.println(rsc.status.getResponseDescription());
+        }
+        rsc.close();
+    }
+}
+
+
+// Todo: implement RSSI at some point
+
 void receiveE220Message() {
 	// If something available
-  if (e220ttl.available() > 1) {
+  if (e220.available() > 1) {
 	  // read the String message
 #ifdef ENABLE_RSSI
 	ResponseContainer rc = e220tt.receiveMessageRSSI();
 #else
-	ResponseContainer rc = e220ttl.receiveMessage();
+	ResponseContainer rc = e220.receiveMessage();
 #endif
 	// Is something goes wrong print error
 	if (rc.status.code!=1){
@@ -61,18 +81,21 @@ void receiveE220Message() {
 }
 }
 
+/*
+*/
+
 
 
 
 /*
   // |================< E220 Communication >==================|
 	// If something available
-  if (e220ttl.available()>1) {
+  if (e220.available()>1) {
 	  // read the String message
 #ifdef ENABLE_RSSI
 	ResponseContainer rc = e220tt.receiveMessageRSSI();
 #else
-	ResponseContainer rc = e220ttl.receiveMessage();
+	ResponseContainer rc = e220.receiveMessage();
 #endif
 	// Is something goes wrong print error
 	if (rc.status.code!=1){
@@ -88,7 +111,7 @@ void receiveE220Message() {
   }
   if (Serial.available()) {
 	  String input = Serial.readString();
-	  ResponseStatus rs = e220ttl.sendBroadcastFixedMessage(69, input);
+	  ResponseStatus rs = e220.sendBroadcastFixedMessage(69, input);
 	  // Check If there is some problem of succesfully send
 	  Serial.println(rs.getResponseDescription());
   }
@@ -106,7 +129,7 @@ void receiveE220Message() {
 //	configuration.SPED.uartBaudRate = UART_BPS_9600;
 //	configuration.SPED.airDataRate = AIR_DATA_RATE_010_24;
 //	configuration.SPED.uartParity = MODE_00_8N1;
-// ResponseStatus rs = e220ttl.setConfiguration(configuration);
+// ResponseStatus rs = e220.setConfiguration(configuration);
 //	configuration.OPTION.subPacketSetting = SPS_200_00;
 //	configuration.OPTION.RSSIAmbientNoise = RSSI_AMBIENT_NOISE_DISABLED;
 //	configuration.OPTION.transmissionPower = POWER_22;

--- a/sketches/E220_GOOD_PRACTICE/E220.h
+++ b/sketches/E220_GOOD_PRACTICE/E220.h
@@ -16,11 +16,23 @@
 
 #define comChan 69
 
+
+// <================================<< STRUCT >>================================>
+// hier?
+struct GpsData {
+    float lat;
+    float lon;
+    float alt;
+    uint8_t sat;
+};
+
+
 extern LoRa_E220 e220ttl;
 
 void initE220();
 void configE220();
 void sendE220Message(int channel, const String& message);
 void receiveE220Message();
+void gpsDataRX();
 
 #endif

--- a/sketches/E220_GOOD_PRACTICE/E220_GOOD_PRACTICE.ino
+++ b/sketches/E220_GOOD_PRACTICE/E220_GOOD_PRACTICE.ino
@@ -40,16 +40,23 @@ void setup() {
 // <================================<< LOOP >>=================================>
 void loop() {
   // |=============< E220 Communication >==============|
-receiveE220Message();
-  ResponseContainer rc = e220ttl.receiveMessage();
+  // === RX ===
+
+//receiveE220Message();
+//ResponseContainer rc = e220ttl.receiveMessage();
+
+gpsDataRX();
+LEDcycle(pink);
+
+  // === TX ===
 sendE220Message(comChan, "Can you hear me?");
 //sendE220Message(comChan, "Please, send me a message!");
   LEDR_COLOR(1, dim_blue, 100);
-  if (rc.status.code != 1)
+  if (rsc.status.code != 1)
   {
   LEDR_COLOR(15, dim_red, 100);
   }else{
-  Serial.println(rc.data);
+  Serial.println(rsc.data);
   LEDR_COLOR(15, dim_green, 100);
   }
 
@@ -94,7 +101,7 @@ sendE220Message(comChan, "Can you hear me?");
     }
 
   // |=============< E220 Communication >==============|
-receiveE220Message();
+//receiveE220Message();
 
   /// end loop ///
 }

--- a/sketches/GPSv3_esp32_LoRa_RX/GPSv3_esp32_LoRa_RX.ino
+++ b/sketches/GPSv3_esp32_LoRa_RX/GPSv3_esp32_LoRa_RX.ino
@@ -1,0 +1,58 @@
+#include "Arduino.h"
+#include "LoRa_E220.h"
+
+#define FREQUENCY_868
+#define DESTINATION_ADDL BROADCAST_ADDRESS
+#define TX_PIN 17
+#define RX_PIN 16
+#define AUX_PIN 4
+#define M0_PIN 2
+#define M1_PIN 15
+LoRa_E220 e220(RX_PIN, TX_PIN, &Serial2, AUX_PIN, M0_PIN, M1_PIN, UART_BPS_RATE_9600);
+
+const int COM_CHAN = 69;
+
+struct GpsData {
+    float lat;
+    float lon;
+    float alt;
+    uint8_t sat;
+};
+
+void setup() {
+    Serial.begin(115200);
+    e220.begin();
+    ResponseStructContainer c = e220.getConfiguration();
+    Configuration config = *(Configuration*)c.data;
+    config.ADDL = BROADCAST_ADDRESS;
+    config.ADDH = BROADCAST_ADDRESS;
+    config.CHAN = COM_CHAN;
+    config.SPED.uartBaudRate = UART_BPS_9600;
+    config.SPED.airDataRate = AIR_DATA_RATE_010_24;
+    config.SPED.uartParity = MODE_00_8N1;
+    config.OPTION.subPacketSetting = SPS_200_00;
+    config.OPTION.RSSIAmbientNoise = RSSI_AMBIENT_NOISE_DISABLED;
+    config.OPTION.transmissionPower = POWER_22;
+    config.TRANSMISSION_MODE.fixedTransmission = FT_FIXED_TRANSMISSION;
+    config.TRANSMISSION_MODE.enableRSSI = RSSI_DISABLED;
+    config.TRANSMISSION_MODE.enableLBT = LBT_DISABLED;
+    config.TRANSMISSION_MODE.WORPeriod = WOR_2000_011;
+    e220.setConfiguration(config, WRITE_CFG_PWR_DWN_SAVE);
+    c.close();
+}
+
+void loop() {
+    if (e220.available() > 1) {
+        ResponseStructContainer rsc = e220.receiveMessage(sizeof(GpsData));
+        if (rsc.status.code == 1) {
+            GpsData data = *(GpsData*)rsc.data;
+            Serial.print(F("Lat: ")); Serial.print(data.lat, 6);
+            Serial.print(F(" Lon: ")); Serial.print(data.lon, 6);
+            Serial.print(F(" Alt: ")); Serial.print(data.alt);
+            Serial.print(F(" Sat: ")); Serial.println(data.sat);
+        } else {
+            Serial.println(rsc.status.getResponseDescription());
+        }
+        rsc.close();
+    }
+}

--- a/sketches/GPSv3_esp32_LoRa_TX/GPSv3_esp32_LoRa_TX.ino
+++ b/sketches/GPSv3_esp32_LoRa_TX/GPSv3_esp32_LoRa_TX.ino
@@ -1,0 +1,70 @@
+#include "Arduino.h"
+#include "LoRa_E220.h"
+#include <TinyGPSPlus.h>
+#include <HardwareSerial.h>
+
+#define FREQUENCY_868
+#define DESTINATION_ADDL BROADCAST_ADDRESS
+#define TX_PIN 17
+#define RX_PIN 16
+#define AUX_PIN 4
+#define M0_PIN 2
+#define M1_PIN 15
+LoRa_E220 e220(RX_PIN, TX_PIN, &Serial2, AUX_PIN, M0_PIN, M1_PIN, UART_BPS_RATE_9600);
+
+TinyGPSPlus gps;
+HardwareSerial gpsSerial(1);
+
+const int RXPinGPS = 33;
+const int TXPinGPS = 32;
+const uint32_t GPSBaud = 9600;
+const int COM_CHAN = 69;
+
+struct GpsData {
+    float lat;
+    float lon;
+    float alt;
+    uint8_t sat;
+};
+
+void setup() {
+    gpsSerial.begin(GPSBaud, SERIAL_8N1, RXPinGPS, TXPinGPS);
+    Serial.begin(115200);
+
+    e220.begin();
+    ResponseStructContainer c = e220.getConfiguration();
+    Configuration config = *(Configuration*)c.data;
+    config.ADDL = BROADCAST_ADDRESS;
+    config.ADDH = BROADCAST_ADDRESS;
+    config.CHAN = COM_CHAN;
+    config.SPED.uartBaudRate = UART_BPS_9600;
+    config.SPED.airDataRate = AIR_DATA_RATE_010_24;
+    config.SPED.uartParity = MODE_00_8N1;
+    config.OPTION.subPacketSetting = SPS_200_00;
+    config.OPTION.RSSIAmbientNoise = RSSI_AMBIENT_NOISE_DISABLED;
+    config.OPTION.transmissionPower = POWER_22;
+    config.TRANSMISSION_MODE.fixedTransmission = FT_FIXED_TRANSMISSION;
+    config.TRANSMISSION_MODE.enableRSSI = RSSI_DISABLED;
+    config.TRANSMISSION_MODE.enableLBT = LBT_DISABLED;
+    config.TRANSMISSION_MODE.WORPeriod = WOR_2000_011;
+    e220.setConfiguration(config, WRITE_CFG_PWR_DWN_SAVE);
+    c.close();
+}
+
+void loop() {
+    while (gpsSerial.available()) {
+        gps.encode(gpsSerial.read());
+    }
+
+    if (gps.location.isUpdated()) {
+        GpsData data;
+        data.lat = gps.location.lat();
+        data.lon = gps.location.lng();
+        data.alt = gps.altitude.meters();
+        data.sat = gps.satellites.value();
+
+        ResponseStatus rs = e220.sendFixedMessage(0, DESTINATION_ADDL, COM_CHAN, &data, sizeof(GpsData));
+        Serial.print(F("Send status: ")); Serial.println(rs.getResponseDescription());
+        delay(1000);
+    }
+}


### PR DESCRIPTION
## Summary
- add new `GPSv3_esp32_LoRa_TX` sketch to send GPS data over an E220 radio
- add `GPSv3_esp32_LoRa_RX` example that receives and prints the transmitted data
- document the sketches in the README

## Testing
- `arduino-cli core update-index` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687fdbb8b53c833391875bbdd0139856