### PR TITLE
Display booting text for cube demo

### DIFF
--- a/sketches/BNO055_LCD_CUBE/BNO055_LCD_CUBE.ino
+++ b/sketches/BNO055_LCD_CUBE/BNO055_LCD_CUBE.ino
@@ -78,6 +78,8 @@ void setup() {
   bno.setExtCrystalUse(true);
   initLCD();
   displayText("booting...");
+  delay(1000);
+}
 
 
 // Apply yaw (h), roll (r) and pitch (p) rotations to vector v


### PR DESCRIPTION
## Summary
- display "booting..." message during setup and keep it on screen briefly
- close `setup()` function properly

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688531b703908333b83837a899c21d4c