### PR TITLE
Add rotating LCD compass with start reference

### DIFF
--- a/sketches/GY-BNO055_LCD_COMPASS/GY-BNO055_LCD_COMPASS.ino
+++ b/sketches/GY-BNO055_LCD_COMPASS/GY-BNO055_LCD_COMPASS.ino
@@ -1,0 +1,39 @@
+#include <Adafruit_Sensor.h>
+#include <Adafruit_BNO055.h>
+
+#include "LCD_GC9A01A.h"
+
+// The BNO055 fuses gyro, accelerometer and magnetometer data internally.
+// We'll display the resulting compass heading on the LCD for debugging.
+Adafruit_BNO055 bno = Adafruit_BNO055(55, 0x29);
+
+float startHeading = 0.0f;
+
+float readHeading() {
+  imu::Vector<3> euler = bno.getVector(Adafruit_BNO055::VECTOR_EULER);
+  float h = -euler.x();
+  if (h < 0) {
+    h += 360.0f;
+  }
+  Serial.print("Heading: ");
+  Serial.println(h);
+  return h;
+}
+
+void setup() {
+  Serial.begin(115200);
+  if (!bno.begin()) {
+    Serial.println("Ooops, no BNO055 detected ... Check wiring!");
+    while (1);
+  }
+  bno.setExtCrystalUse(true);
+  initLCD();
+  delay(100); // allow sensor to stabilize
+  startHeading = readHeading();
+}
+
+void loop() {
+  float h = readHeading();
+  displayCompass(h, startHeading);
+  delay(1000);
+}

--- a/sketches/GY-BNO055_LCD_COMPASS/LCD_GC9A01A.cpp
+++ b/sketches/GY-BNO055_LCD_COMPASS/LCD_GC9A01A.cpp
@@ -1,0 +1,52 @@
+#include "LCD_GC9A01A.h"
+
+Adafruit_GC9A01A tft = Adafruit_GC9A01A(TFT_CS, TFT_DC, TFT_RST);
+
+void initLCD() {
+  tft.begin();
+  tft.setRotation(2);
+  tft.fillScreen(GC9A01A_BLACK);
+  tft.setTextSize(2);
+  tft.setTextColor(GC9A01A_WHITE);
+}
+
+void clearLCD() {
+  tft.fillScreen(GC9A01A_BLACK);
+}
+
+void displayCompass(float heading, float startHeading) {
+  clearLCD();
+  int16_t x1, y1;
+  uint16_t w, h;
+
+  int cx = 120;
+  int cy = 120;
+  int radius = 80;
+  tft.drawCircle(cx, cy, radius, GC9A01A_WHITE);
+
+  // rotate the compass labels so north stays at the top
+  float hRad = heading * 0.01745329251; // DEG_TO_RAD
+  struct { const char *label; float angle; } labels[4] = {
+    {"N", 0}, {"E", 90}, {"S", 180}, {"W", 270}
+  };
+
+  for (auto &l : labels) {
+    float a = (l.angle - heading) * 0.01745329251;
+    int tx = cx + (int)((radius + 12) * sin(a)) - 4;
+    int ty = cy - (int)((radius + 12) * cos(a)) + 4;
+    tft.setCursor(tx, ty);
+    tft.print(l.label);
+  }
+
+  // Arrow to the starting heading
+  float arrowAngle = (startHeading - heading) * 0.01745329251;
+  int len = radius - 10;
+  int x2 = cx + (int)(len * sin(arrowAngle));
+  int y2 = cy - (int)(len * cos(arrowAngle));
+  tft.drawLine(cx, cy, x2, y2, GC9A01A_RED);
+
+  String text = String(heading, 1) + " deg";
+  tft.getTextBounds(text, 0, 0, &x1, &y1, &w, &h);
+  tft.setCursor((240 - w) / 2, cy + radius + 20);
+  tft.print(text);
+}

--- a/sketches/GY-BNO055_LCD_COMPASS/LCD_GC9A01A.h
+++ b/sketches/GY-BNO055_LCD_COMPASS/LCD_GC9A01A.h
@@ -1,0 +1,21 @@
+#ifndef LCD_GC9A01A_H
+#define LCD_GC9A01A_H
+// =======================<< LCD >>==============================
+#include <Adafruit_GFX.h>
+#include <Adafruit_GC9A01A.h>
+#include <SPI.h>
+
+#define TFT_CS    5   // Chip select control pin
+#define TFT_RST   19
+#define TFT_DC    13 // because it is being used by E220
+#define TFT_SDA   23  // SPI Data (MOSI)
+#define TFT_SCL   18  // SPI Clock (SCK)
+
+extern Adafruit_GC9A01A tft;
+
+void initLCD();
+void clearLCD();
+void displayCompass(float heading, float startHeading);
+
+
+#endif 


### PR DESCRIPTION
## Summary
- compute initial heading as reference
- rotate compass dial relative to magnetic north while arrow points to start direction
- update LCD helper accordingly

## Testing
- `arduino-cli version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68853256256c833388452bffef9e73ed