### PR TITLE
Add adjustable compass arrows

### DIFF
--- a/sketches/GY-BNO055_LCD_COMPASS/GY-BNO055_LCD_COMPASS.ino
+++ b/sketches/GY-BNO055_LCD_COMPASS/GY-BNO055_LCD_COMPASS.ino
@@ -2,12 +2,13 @@
 #include <Adafruit_BNO055.h>
 
 #include "LCD_GC9A01A.h"
+#include <math.h>
 
 // The BNO055 fuses gyro, accelerometer and magnetometer data internally.
 // We'll display the resulting compass heading on the LCD for debugging.
 Adafruit_BNO055 bno = Adafruit_BNO055(55, 0x29);
 
-float startHeading = 0.0f;
+float needleHeading = 0.0f;
 
 float readHeading() {
   imu::Vector<3> euler = bno.getVector(Adafruit_BNO055::VECTOR_EULER);
@@ -29,11 +30,22 @@ void setup() {
   bno.setExtCrystalUse(true);
   initLCD();
   delay(100); // allow sensor to stabilize
-  startHeading = readHeading();
 }
 
 void loop() {
+  if (Serial.available()) {
+    char c = Serial.read();
+    if (c == 'l') {
+      needleHeading -= 5.0f;
+    } else if (c == 'r') {
+      needleHeading += 5.0f;
+    }
+    if (needleHeading > 180.0f) needleHeading -= 360.0f;
+    if (needleHeading < -180.0f) needleHeading += 360.0f;
+  }
+
   float h = readHeading();
-  displayCompass(h, startHeading);
-  delay(1000);
+  bool aligned = fabs(needleHeading) < 5.0f;
+  displayCompass(h, needleHeading, aligned);
+  delay(200);
 }

--- a/sketches/GY-BNO055_LCD_COMPASS/LCD_GC9A01A.cpp
+++ b/sketches/GY-BNO055_LCD_COMPASS/LCD_GC9A01A.cpp
@@ -14,7 +14,7 @@ void clearLCD() {
   tft.fillScreen(GC9A01A_BLACK);
 }
 
-void displayCompass(float heading, float startHeading) {
+void displayCompass(float heading, float needleHeading, bool aligned) {
   clearLCD();
   int16_t x1, y1;
   uint16_t w, h;
@@ -38,12 +38,20 @@ void displayCompass(float heading, float startHeading) {
     tft.print(l.label);
   }
 
-  // Arrow to the starting heading
-  float arrowAngle = (startHeading - heading) * 0.01745329251;
+  // Arrow pointing to magnetic north
+  float northAngle = (0 - heading) * 0.01745329251;
   int len = radius - 10;
-  int x2 = cx + (int)(len * sin(arrowAngle));
-  int y2 = cy - (int)(len * cos(arrowAngle));
-  tft.drawLine(cx, cy, x2, y2, GC9A01A_RED);
+  int nx = cx + (int)(len * sin(northAngle));
+  int ny = cy - (int)(len * cos(northAngle));
+  uint16_t northColor = aligned ? GC9A01A_GREEN : GC9A01A_WHITE;
+  tft.drawLine(cx, cy, nx, ny, northColor);
+
+  // Arrow that can be rotated by the user
+  float needleAngle = (needleHeading - heading) * 0.01745329251;
+  int x2 = cx + (int)(len * sin(needleAngle));
+  int y2 = cy - (int)(len * cos(needleAngle));
+  uint16_t needleColor = aligned ? GC9A01A_GREEN : GC9A01A_RED;
+  tft.drawLine(cx, cy, x2, y2, needleColor);
 
   String text = String(heading, 1) + " deg";
   tft.getTextBounds(text, 0, 0, &x1, &y1, &w, &h);

--- a/sketches/GY-BNO055_LCD_COMPASS/LCD_GC9A01A.h
+++ b/sketches/GY-BNO055_LCD_COMPASS/LCD_GC9A01A.h
@@ -15,7 +15,7 @@ extern Adafruit_GC9A01A tft;
 
 void initLCD();
 void clearLCD();
-void displayCompass(float heading, float startHeading);
+void displayCompass(float heading, float needleHeading, bool aligned);
 
 
 #endif 


### PR DESCRIPTION
## Summary
- show north and adjustable needle on the GC9A01A display
- highlight both arrows in green when aligned
- allow rotating the needle via serial commands

## Testing
- `arduino-cli core update-index` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68855e2863808333a507162c5cf3afd3